### PR TITLE
fix: Ensure panel size min height

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -7,6 +7,11 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: fixed
+
+        Panel size too small at startup.
 
 .. release:: 5.0
     :date: 2021-09-07

--- a/resource/plugin/ftrack.mu
+++ b/resource/plugin/ftrack.mu
@@ -100,7 +100,7 @@ class: FtrackMode : MinorMode
         view.setMaximumWidth(16777215);
         view.setMinimumWidth(0);
         view.setMaximumHeight(16777215);
-        view.setMinimumHeight(0);
+        view.setMinimumHeight(250);
     }
 
     \: makeit (QObject;)


### PR DESCRIPTION
Resolves [ZENDESK-98388](https://ftrack.zendesk.com/agent/tickets/98388)

## Changes
Apply fixes suggested to allow panel to have a min size.

## Test
Build , install and ensure panel has the rigth size at startup
