### PR TITLE
fix: selections not working

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -10,6 +10,11 @@ Release Notes
 .. release:: Upcoming
 
     .. change:: fixed
+        :tags: Api
+
+        Rv does not play Entity selections.
+
+    .. change:: fixed
         :tags: Logging
 
         Log initialization breaks due to utf8 conversion.
@@ -23,6 +28,7 @@ Release Notes
         :tags: UX
 
         Panel size too small at startup.
+
 
 .. release:: 5.0
     :date: 2021-09-07

--- a/resource/plugin/ftrack_rv_api.py
+++ b/resource/plugin/ftrack_rv_api.py
@@ -374,15 +374,21 @@ def _translateEntityType(entityType):
         'Unable to translate entity type: {0}.'.format(entity_type)
     )
 
+def _get_temp_data_url(name, temp_data_id):
+    operation = {
+        'action': 'get_widget_url',
+        'name': name,
+        'theme': None,
+    }
 
-def _get_temp_data(temp_data_id):
-    action = {'action': '_get_tempdata', 'id': temp_data_id}
-    logger.info('tempdata Action {}'.format(action))
-    return session.call([action])
-
+    result = session.call([operation])
+    url = result[0]['widget_url']
+    full_url = '{}&entityType=tempdata&entityId={}'.format(url, temp_data_id)
+    return full_url
 
 def _generateURL(params=None, panelName=None):
     '''Return URL to panel in ftrack based on *params* or *panel*.'''
+    logger.info('_generateURL with params: {}'.format(params))
     url = ''
     try:
         entityId = None
@@ -401,16 +407,17 @@ def _generateURL(params=None, panelName=None):
                 if (entityType != 'tempdata') :   
                     new_entity_type = _translateEntityType(entityType)
                     new_entity = session.get(new_entity_type, entityId)
+                    try:
+                        logger.info('URL Generated for: {}'.format(new_entity))
+                        url = session._get_widget_url(panelName, entity=new_entity)
+                    except Exception as exception:
+                        logger.error(str(exception))
+
                 else: 
-                    temp_data = _get_temp_data(entityId)[0][0]
-                    new_entity_type = _translateEntityType(temp_data['type'])
-                    new_entity = session.get(new_entity_type, temp_data['id'])
-            else:
-                new_entity = None
-            try:
-                url = session.get_widget_url(panelName, entity=new_entity)
-            except Exception as exception:
-                logger.error(str(exception))
+                    try:
+                        url = _get_temp_data_url(panelName, entityId)
+                    except Exception as exception:
+                        logger.error(str(exception))
 
         logger.info('Returning url "{0}"'.format(url))
     except Exception as error:

--- a/resource/plugin/ftrack_rv_api.py
+++ b/resource/plugin/ftrack_rv_api.py
@@ -408,11 +408,9 @@ def _generateURL(params=None, panelName=None):
                     new_entity_type = _translateEntityType(entityType)
                     new_entity = session.get(new_entity_type, entityId)
                     try:
-                        logger.info('URL Generated for: {}'.format(new_entity))
                         url = session.get_widget_url(panelName, entity=new_entity)
                     except Exception as exception:
                         logger.error(str(exception))
-
                 else: 
                     try:
                         url = _get_temp_data_url(panelName, entityId)

--- a/resource/plugin/ftrack_rv_api.py
+++ b/resource/plugin/ftrack_rv_api.py
@@ -409,7 +409,7 @@ def _generateURL(params=None, panelName=None):
                     new_entity = session.get(new_entity_type, entityId)
                     try:
                         logger.info('URL Generated for: {}'.format(new_entity))
-                        url = session._get_widget_url(panelName, entity=new_entity)
+                        url = session.get_widget_url(panelName, entity=new_entity)
                     except Exception as exception:
                         logger.error(str(exception))
 


### PR DESCRIPTION

Resolves ZENDESK-98469
- [ ] I have added automatic tests where applicable.
- [X] The PR contains a description of what has been changed.
- [X] The description contains manual test instructions.
- [X] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
Provide separate hacky method to allow temp data from selection to be rendered in widget.

## Test
NOTE: Please ensure you have set Bake RVLINK to True in setttings.

1) select a bunch of entities (Tasks, AssetVersion) and click play with -> RV
2) select a list of click play with -> RV


